### PR TITLE
chore: bump versions for per-signal OTLP endpoint support

### DIFF
--- a/charts/openlit-controller/Chart.yaml
+++ b/charts/openlit-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openlit-controller
 description: OpenLIT Controller - Zero-code LLM and Agent observability using eBPF
 type: application
-version: 0.1.1
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 home: https://openlit.io
 sources:
   - https://github.com/openlit/openlit

--- a/charts/openlit/Chart.yaml
+++ b/charts/openlit/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openlit
 description: A Helm chart for OpenLIT
 type: application
-version: 1.19.1
-appVersion: 1.19.0
+version: 1.20.0
+appVersion: 1.20.0
 icon: https://avatars.githubusercontent.com/u/149867240?s=200&v=4
 home: https://openlit.io
 sources:
@@ -22,7 +22,7 @@ maintainers:
     url: https://openlit.io
 dependencies:
   - name: openlit-controller
-    version: "0.1.1"
+    version: "0.2.0"
     repository: "file://../openlit-controller"
     condition: openlit-controller.enabled
     tags:


### PR DESCRIPTION
- openlit-controller chart: 0.1.1 -> 0.2.0, appVersion 0.2.0
- openlit chart: 1.19.1 -> 1.20.0, appVersion 1.20.0
- Update controller dependency version to 0.2.0

No template changes needed — per-signal OTLP config flows through the poll API, not Helm values.